### PR TITLE
Use invariant culture when converting numbers

### DIFF
--- a/ChargeBee/Api/Params.cs
+++ b/ChargeBee/Api/Params.cs
@@ -66,7 +66,7 @@ namespace ChargeBee.Api
 		private static object ConvertValue(object value, bool isDate) {
 			if (value is string || value is int || value is long
 			    || value is double) {
-				return value.ToString ();
+				return Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture);
 			} else if (value is bool) {
 				return value.ToString ().ToLower ();
 			} else if (value is Enum) {


### PR DESCRIPTION
It fixes a bug with coupons creation on OS that use "," as the decimal symbol instead of "."