### PR TITLE
ApiUtil,the APIConfig.ConnectTimeout value can be 0

### DIFF
--- a/ChargeBee/Api/ApiUtil.cs
+++ b/ChargeBee/Api/ApiUtil.cs
@@ -18,7 +18,7 @@ namespace ChargeBee.Api
     public static class ApiUtil
     {
         private static DateTime m_unixTime = new DateTime(1970, 1, 1);
-        private static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromMilliseconds(ApiConfig.ConnectTimeout) };
+        private static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromMilliseconds( ApiConfig.ConnectTimeout > 0 ? ApiConfig.ConnectTimeout : 15000) };
 
         public static string BuildUrl(params string[] paths)
         {


### PR DESCRIPTION
When handling a webhook and attempting Subscription.Retrieve(subscriptionId).Request() , it fails due to HttpClient Timeout being 0 , even though current instance of ApiConfig.ConnectTimeout is default 15000.
This did work correctly in version 2.5.8