### PR TITLE
Limit item applicability to be required for plan items only

### DIFF
--- a/ChargeBee/Models/Item.cs
+++ b/ChargeBee/Models/Item.cs
@@ -127,7 +127,7 @@ namespace ChargeBee.Models
         }
         public ItemApplicabilityEnum ItemApplicability 
         {
-            get { return GetEnum<ItemApplicabilityEnum>("item_applicability", true); }
+            get { return GetEnum<ItemApplicabilityEnum>("item_applicability", ItemType == TypeEnum.Plan); }
         }
         public string GiftClaimRedirectUrl 
         {


### PR DESCRIPTION
Only Plans will contain the `item_applicability` property. 

The documentation describes this property as: 
_"Indicates which addon-items and charge-items can be applied to the item. Only possible for plan-items. Other details of attaching items such as whether to attach as a mandatory item or to attach on a certain event, can be specified using the Create or Update an attached item API."_

The Product Catalog V2 contains multiple types of items - plans, addons and charges. 
So when requesting a list of items in the Product Catalog V2, the result will throw an exception when getting the property - say, for instance while serializing the result as json. 