### PR TITLE
Adding multi site support #34

### DIFF
--- a/ChargeBee/Api/ApiConfig.cs
+++ b/ChargeBee/Api/ApiConfig.cs
@@ -53,13 +53,21 @@ namespace ChargeBee.Api
 
         public static void Configure(string siteName, string apiKey)
         {
+            m_instance = Create(siteName, apiKey);
+        }
+
+        public static ApiConfig Create(string siteName, string apiKey)
+        {
+            if (m_instance != null)
+                throw new Exception("Already configured statically!");
+
             if (String.IsNullOrEmpty(siteName))
                 throw new ArgumentException("Site name can't be empty!");
 
             if (String.IsNullOrEmpty(apiKey))
                 throw new ArgumentException("Api key can't be empty!");
 
-            m_instance = new ApiConfig(siteName, apiKey);
+            return new ApiConfig(siteName, apiKey);
         }
 
         public static ApiConfig Instance

--- a/ChargeBee/Api/ApiConfig.cs
+++ b/ChargeBee/Api/ApiConfig.cs
@@ -15,7 +15,6 @@ namespace ChargeBee.Api
         public string ApiKey { get; set; }
         public string SiteName { get; set; }
         public string Charset { get; set; }
-        public static int ConnectTimeout { get; set; }
 
         public string ApiBaseUrl
         {
@@ -42,7 +41,6 @@ namespace ChargeBee.Api
         private ApiConfig(string siteName, string apiKey)
         {
             Charset = Encoding.UTF8.WebName;
-            ConnectTimeout = 15000; 
             TimeTravelMillis = 3000;
             ExportSleepMillis = 10000;
             SiteName = siteName;

--- a/ChargeBee/Api/ApiUtil.cs
+++ b/ChargeBee/Api/ApiUtil.cs
@@ -22,7 +22,7 @@ namespace ChargeBee.Api
 
         public static string BuildUrl(params string[] paths)
         {
-            StringBuilder sb = new StringBuilder(ApiConfig.Instance.ApiBaseUrl);
+            StringBuilder sb = new StringBuilder();
 
             foreach (var path in paths)
             {
@@ -38,14 +38,14 @@ namespace ChargeBee.Api
             {
                 byte[] paramBytes = Encoding.GetEncoding(env.Charset).GetBytes(parameters.GetQuery(false));
                 string postData = Encoding.GetEncoding(env.Charset).GetString(paramBytes, 0, paramBytes.Length);
-                request = new HttpRequestMessage(meth, new Uri(url))
+                request = new HttpRequestMessage(meth, new Uri($"{env.ApiBaseUrl}{url}"))
                 {
                     Content = new StringContent(postData, Encoding.UTF8, "application/x-www-form-urlencoded")
                 };
             }
             else
             {
-                request = new HttpRequestMessage(meth, new Uri(url));
+                request = new HttpRequestMessage(meth, new Uri($"{env.ApiBaseUrl}{url}"));
             }
             return request;
         }

--- a/ChargeBee/Api/ApiUtil.cs
+++ b/ChargeBee/Api/ApiUtil.cs
@@ -18,8 +18,8 @@ namespace ChargeBee.Api
     public static class ApiUtil
     {
         private static DateTime m_unixTime = new DateTime(1970, 1, 1);
-        private static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromMilliseconds(ApiConfig.ConnectTimeout) };
-
+        private static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromMilliseconds(15000) };
+        
         public static string BuildUrl(params string[] paths)
         {
             StringBuilder sb = new StringBuilder();

--- a/README.md
+++ b/README.md
@@ -29,16 +29,30 @@ See our [.Net API Reference](https://apidocs.chargebee.com/docs/api?lang=dotnet 
 ## Usage
 
 To create a new subscription:
-  
-    using ChargeBee.Api;
-	using ChargeBee.Models;
-	ApiConfig.Configure("site","api_key");
-	EntityResult result = Subscription.Create()
-                  .PlanId("basic")
-				  .Request();
-	Subscription subscription = result.Subscription;
-	Customer customer = result.Customer;
+```
+using ChargeBee.Api;
+using ChargeBee.Models;
 
+ApiConfig.Configure("site","api_key");
+EntityResult result = Subscription.Create()
+			.PlanId("basic")
+			.Request();
+Subscription subscription = result.Subscription;
+Customer customer = result.Customer;
+```
+
+To create a new subscription with a multi site configuration:
+```
+using ChargeBee.Api;
+using ChargeBee.Models;
+
+ApiConfig env = ApiConfig.Create("site","api_key");
+EntityResult result = await Subscription.Create()
+			.PlanId("basic")
+			.RequestAsync(env);
+Subscription subscription = result.Subscription;
+Customer customer = result.Customer;
+```
 ## License
 
 See the LICENSE file.


### PR DESCRIPTION
The static setup does not work if you need to connect to different Chargebee sites.
Made it work with minimal changes.

- Added an ApiConfig.Create method
- Moved the usage of the basepath to BuildRequest.
- Also added a usage example to the readme

