### PR TITLE
Make has_scheduled_advance_invoices non required

### DIFF
--- a/ChargeBee/Models/Subscription.cs
+++ b/ChargeBee/Models/Subscription.cs
@@ -369,7 +369,7 @@ namespace ChargeBee.Models
         }
         public bool HasScheduledAdvanceInvoices 
         {
-            get { return GetValue<bool>("has_scheduled_advance_invoices", true); }
+            get { return GetValue<bool>("has_scheduled_advance_invoices", false); }
         }
         public bool HasScheduledChanges 
         {


### PR DESCRIPTION
The API doesn't return `has_scheduled_advance_invoices`.

Fixes #44 