### PR TITLE
Added httpclient param to ApiConfig, set minimum .NET Framework version to 4.6.2. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ UpgradeLog*.XML
 Icon?
 G# Thumbnails
 ._*
+/.vs

--- a/ChargeBee/Api/ApiConfig.cs
+++ b/ChargeBee/Api/ApiConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Text;
 using ChargeBee.Internal;
 using Newtonsoft.Json.Linq;
@@ -7,27 +8,39 @@ namespace ChargeBee.Api
 {
     public sealed class ApiConfig
     {
-		public static string DomainSuffix = "chargebee.com";
-		public static string Proto = "https";
-		public static string Version = "2.18.0";
-		public static readonly string API_VERSION = "v2";
+        public static string DomainSuffix = "chargebee.com";
+        public static string Proto = "https";
+        public static string Version = "2.18.0";
+        public static readonly string API_VERSION = "v2";
         public static int TimeTravelMillis { get; set; }
-        public static int ExportSleepMillis { get; set;}
+        public static int ExportSleepMillis { get; set; }
 
         public string ApiKey { get; set; }
         public string SiteName { get; set; }
         public string Charset { get; set; }
-        public static int ConnectTimeout { get; set; }
+        public int ConnectTimeout
+        {
+            get
+            {
+                return HttpClient.Timeout.Milliseconds;
+            }
+            set
+            {
+                HttpClient.Timeout = TimeSpan.FromMilliseconds(0 < value ? value : 30000);
+            }
+        }
+
+        internal HttpClient HttpClient { get; }
 
         public string ApiBaseUrl
         {
             get
             {
-				return String.Format("{0}://{1}.{2}/api/{3}",
+                return String.Format("{0}://{1}.{2}/api/{3}",
                     Proto,
                     SiteName,
                     DomainSuffix,
-					API_VERSION);
+                    API_VERSION);
             }
         }
 
@@ -41,9 +54,8 @@ namespace ChargeBee.Api
             }
         }
 
-        public ApiConfig(string siteName, string apiKey)
+        public ApiConfig(string siteName, string apiKey, HttpClient client = null)
         {
-
             if (String.IsNullOrEmpty(siteName))
                 throw new ArgumentException("Site name can't be empty!");
 
@@ -56,23 +68,36 @@ namespace ChargeBee.Api
             ExportSleepMillis = 10000;
             SiteName = siteName;
             ApiKey = apiKey;
+
+            if (client == null)
+            {
+                HttpClient = new HttpClient
+                {
+                    Timeout = TimeSpan.FromMilliseconds(0 < ConnectTimeout ? ConnectTimeout : 30000)
+                };
+            }
+            else
+            {
+                client.Timeout = TimeSpan.FromMilliseconds(0 < ConnectTimeout ? ConnectTimeout : 30000);
+                HttpClient = client;
+            }
         }
 
         private static volatile ApiConfig m_instance;
 
-        public static void Configure(string siteName, string apiKey)
-        {         
-            m_instance = new ApiConfig(siteName, apiKey);
+        public static void Configure(string siteName, string apiKey, HttpClient client = null)
+        {
+            m_instance = new ApiConfig(siteName, apiKey, client);
         }
 
-        public static string SerializeObject<T>(T t)where T : Resource
+        public static string SerializeObject<T>(T t) where T : Resource
         {
             return t.GetJToken().ToString();
         }
 
-        public static T DeserializeObject<T>(string str)where T : Resource, new()
+        public static T DeserializeObject<T>(string str) where T : Resource, new()
         {
-            JToken JObj = JToken.Parse(str);	
+            JToken JObj = JToken.Parse(str);
             T t = new T();
             t.JObj = JObj;
             return t;
@@ -89,8 +114,9 @@ namespace ChargeBee.Api
             }
         }
 
-        public static void updateConnectTimeoutInMillis(int timeout) {
-                    ConnectTimeout = timeout;
+        public void updateConnectTimeoutInMillis(int timeout)
+        {
+            ConnectTimeout = timeout;
         }
     }
 }

--- a/ChargeBee/ChargeBee.csproj
+++ b/ChargeBee/ChargeBee.csproj
@@ -1,75 +1,77 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
-    <Version>2.18.0</Version>
-    <PackageId>chargebee</PackageId>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageProjectUrl>https://github.com/chargebee/chargebee-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/chargebee/chargebee-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/chargebee/chargebee-dotnet</RepositoryUrl>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ChargeBee</RootNamespace>
-    <AssemblyName>ChargeBee</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\ChargeBee.xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <WarningLevel>4</WarningLevel>
-    <DebugSymbols>true</DebugSymbols>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>Cb-Dotnet.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Cb-Dotnet.snk" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
-  <ProjectExtensions>
-    <MonoDevelop>
-      <Properties>
-        <Policies>
-          <TextStylePolicy inheritsSet="null" scope="application/xml" />
-          <XmlFormattingPolicy scope="application/xml">
-            <DefaultFormat OmitXmlDeclaration="False" IndentContent="True" AttributesInNewLine="False" MaxAttributesPerLine="10" WrapAttributes="False" AlignAttributes="False" AlignAttributeValues="False" QuoteChar="&quot;" SpacesBeforeAssignment="0" SpacesAfterAssignment="0" EmptyLinesBeforeStart="0" EmptyLinesAfterStart="0" EmptyLinesBeforeEnd="0" EmptyLinesAfterEnd="0" />
-          </XmlFormattingPolicy>
-        </Policies>
-      </Properties>
-    </MonoDevelop>
-  </ProjectExtensions>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard1.2;netstandard2.0;net462</TargetFrameworks>
+		<Version>2.18.0</Version>
+		<PackageId>chargebee</PackageId>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageProjectUrl>https://github.com/chargebee/chargebee-dotnet</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/chargebee/chargebee-dotnet/blob/master/LICENSE</PackageLicenseUrl>
+		<RepositoryUrl>https://github.com/chargebee/chargebee-dotnet</RepositoryUrl>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>ChargeBee</RootNamespace>
+		<AssemblyName>ChargeBee</AssemblyName>
+		<FileAlignment>512</FileAlignment>
+		<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+		<RestorePackages>true</RestorePackages>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>True</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<DocumentationFile>bin\Release\ChargeBee.xml</DocumentationFile>
+		<NoWarn>1591</NoWarn>
+		<Prefer32Bit>false</Prefer32Bit>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<Optimize>False</Optimize>
+		<OutputPath>bin\Debug</OutputPath>
+		<WarningLevel>4</WarningLevel>
+		<DebugSymbols>true</DebugSymbols>
+		<Prefer32Bit>false</Prefer32Bit>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<SignAssembly>true</SignAssembly>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<AssemblyOriginatorKeyFile>Cb-Dotnet.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Net.Requests" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="Cb-Dotnet.snk" />
+	</ItemGroup>
+
+	<ProjectExtensions>
+		<MonoDevelop>
+			<Properties>
+				<Policies>
+					<TextStylePolicy inheritsSet="null" scope="application/xml" />
+					<XmlFormattingPolicy scope="application/xml">
+						<DefaultFormat OmitXmlDeclaration="False" IndentContent="True" AttributesInNewLine="False" MaxAttributesPerLine="10" WrapAttributes="False" AlignAttributes="False" AlignAttributeValues="False" QuoteChar="&quot;" SpacesBeforeAssignment="0" SpacesAfterAssignment="0" EmptyLinesBeforeStart="0" EmptyLinesAfterStart="0" EmptyLinesBeforeEnd="0" EmptyLinesAfterEnd="0" />
+					</XmlFormattingPolicy>
+				</Policies>
+			</Properties>
+		</MonoDevelop>
+	</ProjectExtensions>
+
 </Project>


### PR DESCRIPTION
Added option to pass in an existing httpclient to ApiConfig. Refactored ApiUtil to use that client. The timeout property gets and sets the client's timeout directly.
This allows for easier unit / integration testing as well as reuse of HttpClients already available in consuming code.
I set minimum .NET Framework version to 4.6.2 because .NET 4.5 has been out of support for a long time now.