### PR TITLE
Allow to add HttpMessageHandler

### DIFF
--- a/ChargeBee/Api/ApiConfig.cs
+++ b/ChargeBee/Api/ApiConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Text;
 
 namespace ChargeBee.Api
@@ -16,30 +17,22 @@ namespace ChargeBee.Api
         public string SiteName { get; set; }
         public string Charset { get; set; }
         public static int ConnectTimeout { get; set; }
+        
+        public static HttpMessageHandler HttpMessageHandler { get; set; }
 
-        public string ApiBaseUrl
-        {
-            get
-            {
-				return String.Format("{0}://{1}.{2}/api/{3}",
-                    Proto,
-                    SiteName,
-                    DomainSuffix,
-					API_VERSION);
-            }
-        }
+        public string ApiBaseUrl =>
+            String.Format("{0}://{1}.{2}/api/{3}",
+                Proto,
+                SiteName,
+                DomainSuffix,
+                API_VERSION);
 
-        public string AuthValue
-        {
-            get
-            {
-                return String.Format("Basic {0}",
-                    Convert.ToBase64String(Encoding.UTF8.GetBytes(
+        public string AuthValue =>
+            String.Format("Basic {0}",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(
                     String.Format("{0}:", ApiKey))));
-            }
-        }
 
-        public ApiConfig(string siteName, string apiKey)
+        public ApiConfig(string siteName, string apiKey, HttpMessageHandler httpMessageHandler = null)
         {
 
             if (String.IsNullOrEmpty(siteName))
@@ -54,13 +47,14 @@ namespace ChargeBee.Api
             ExportSleepMillis = 10000;
             SiteName = siteName;
             ApiKey = apiKey;
+            HttpMessageHandler = httpMessageHandler;
         }
 
         private static volatile ApiConfig m_instance;
 
-        public static void Configure(string siteName, string apiKey)
+        public static void Configure(string siteName, string apiKey, HttpMessageHandler httpMessageHandler = null)
         {         
-            m_instance = new ApiConfig(siteName, apiKey);
+            m_instance = new ApiConfig(siteName, apiKey, httpMessageHandler);
         }
 
         public static ApiConfig Instance

--- a/ChargeBee/Api/ApiUtil.cs
+++ b/ChargeBee/Api/ApiUtil.cs
@@ -6,9 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-
 using Newtonsoft.Json;
-
 using ChargeBee.Exceptions;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -18,7 +16,12 @@ namespace ChargeBee.Api
     public static class ApiUtil
     {
         private static DateTime m_unixTime = new DateTime(1970, 1, 1);
-        private static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromMilliseconds(0 < ApiConfig.ConnectTimeout ? ApiConfig.ConnectTimeout : 30000) };
+
+        private static readonly HttpClient httpClient =
+            new HttpClient(ApiConfig.HttpMessageHandler ?? new HttpClientHandler())
+            {
+                Timeout = TimeSpan.FromMilliseconds(0 < ApiConfig.ConnectTimeout ? ApiConfig.ConnectTimeout : 30000)
+            };
 
         public static string BuildUrl(params string[] paths)
         {
@@ -28,8 +31,10 @@ namespace ChargeBee.Api
             {
                 sb.Append('/').Append(Uri.EscapeDataString(path));
             }
+
             return sb.ToString();
         }
+
         private static HttpRequestMessage BuildRequest(string uri, HttpMethod method, Params parameters, ApiConfig env)
         {
             HttpRequestMessage request;
@@ -47,15 +52,19 @@ namespace ChargeBee.Api
             {
                 request = new HttpRequestMessage(meth, new Uri($"{env.ApiBaseUrl}{uri}"));
             }
+
             return request;
         }
-        private static HttpRequestMessage GetRequestMessage(string url, HttpMethod method, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+
+        private static HttpRequestMessage GetRequestMessage(string url, HttpMethod method, Params parameters,
+            Dictionary<string, string> headers, ApiConfig env)
         {
             HttpRequestMessage request = BuildRequest(url, method, parameters, env);
             AddHeaders(request, env);
             AddCustomHeaders(request, headers);
             return request;
         }
+
         private static void AddHeaders(HttpRequestMessage request, ApiConfig env)
         {
             request.Headers.Add("Accept-Charset", env.Charset);
@@ -96,14 +105,26 @@ namespace ChargeBee.Api
             }
             catch (JsonException e)
             {
-                if(content.Contains("503")){
-                   throw new ArgumentException("Sorry, the server is currently unable to handle the request due to a temporary overload or scheduled maintenance. Please retry after sometime. \n type: internal_temporary_error, \n http_status_code: 503, \n error_code: internal_temporary_error,\n content: " + content,e);
-                }else if(content.Contains("504")){
-                   throw new ArgumentException("The server did not receive a timely response from an upstream server, request aborted. If this problem persists, contact us at support@chargebee.com. \n type: gateway_timeout, \n http_status_code: 504, \n error_code: gateway_timeout,\n content: " + content, e);
-                }else{
-                   throw new ArgumentException("Sorry, something went wrong when trying to process the request. If this problem persists, contact us at support@chargebee.com. \n type: internal_error, \n http_status_code: 500, \n error_code: internal_error,\n content: " + content,e);
+                if (content.Contains("503"))
+                {
+                    throw new ArgumentException(
+                        "Sorry, the server is currently unable to handle the request due to a temporary overload or scheduled maintenance. Please retry after sometime. \n type: internal_temporary_error, \n http_status_code: 503, \n error_code: internal_temporary_error,\n content: " +
+                        content, e);
+                }
+                else if (content.Contains("504"))
+                {
+                    throw new ArgumentException(
+                        "The server did not receive a timely response from an upstream server, request aborted. If this problem persists, contact us at support@chargebee.com. \n type: gateway_timeout, \n http_status_code: 504, \n error_code: gateway_timeout,\n content: " +
+                        content, e);
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        "Sorry, something went wrong when trying to process the request. If this problem persists, contact us at support@chargebee.com. \n type: internal_error, \n http_status_code: 500, \n error_code: internal_error,\n content: " +
+                        content, e);
                 }
             }
+
             string type = "";
             errorJson.TryGetValue("type", out type);
             if ("payment".Equals(type))
@@ -122,14 +143,17 @@ namespace ChargeBee.Api
             {
                 throw new ApiException(response.StatusCode, errorJson);
             }
-
         }
-        private static EntityResult GetEntityResult(String url, Params parameters, Dictionary<string, string> headers, ApiConfig env, HttpMethod meth)
+
+        private static EntityResult GetEntityResult(String url, Params parameters, Dictionary<string, string> headers,
+            ApiConfig env, HttpMethod meth)
         {
-
-            return GetEntityResultAsync(url, parameters, headers, env, meth).ConfigureAwait(false).GetAwaiter().GetResult();
+            return GetEntityResultAsync(url, parameters, headers, env, meth).ConfigureAwait(false).GetAwaiter()
+                .GetResult();
         }
-        private static async Task<EntityResult> GetEntityResultAsync(String url, Params parameters, Dictionary<string, string> headers, ApiConfig env, HttpMethod meth)
+
+        private static async Task<EntityResult> GetEntityResultAsync(String url, Params parameters,
+            Dictionary<string, string> headers, ApiConfig env, HttpMethod meth)
         {
             HttpRequestMessage request = GetRequestMessage(url, meth, parameters, headers, env);
             var response = await httpClient.SendAsync(request).ConfigureAwait(false);
@@ -145,12 +169,15 @@ namespace ChargeBee.Api
                 return null;
             }
         }
-        public static EntityResult Post(string url, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+
+        public static EntityResult Post(string url, Params parameters, Dictionary<string, string> headers,
+            ApiConfig env)
         {
             return GetEntityResult(url, parameters, headers, env, HttpMethod.POST);
         }
 
-        public static Task<EntityResult> PostAsync(string url, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+        public static Task<EntityResult> PostAsync(string url, Params parameters, Dictionary<string, string> headers,
+            ApiConfig env)
         {
             return GetEntityResultAsync(url, parameters, headers, env, HttpMethod.POST);
         }
@@ -161,18 +188,21 @@ namespace ChargeBee.Api
             return GetEntityResult(url, parameters, headers, env, HttpMethod.GET);
         }
 
-        public static Task<EntityResult> GetAsync(string url, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+        public static Task<EntityResult> GetAsync(string url, Params parameters, Dictionary<string, string> headers,
+            ApiConfig env)
         {
             url = String.Format("{0}?{1}", url, parameters.GetQuery(false));
             return GetEntityResultAsync(url, parameters, headers, env, HttpMethod.GET);
         }
 
-        public static ListResult GetList(string url, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+        public static ListResult GetList(string url, Params parameters, Dictionary<string, string> headers,
+            ApiConfig env)
         {
             return GetListAsync(url, parameters, headers, env).GetAwaiter().GetResult();
         }
 
-        public static async Task<ListResult> GetListAsync(string url, Params parameters, Dictionary<string, string> headers, ApiConfig env)
+        public static async Task<ListResult> GetListAsync(string url, Params parameters,
+            Dictionary<string, string> headers, ApiConfig env)
         {
             url = String.Format("{0}?{1}", url, parameters.GetQuery(true));
             HttpRequestMessage request = GetRequestMessage(url, HttpMethod.GET, parameters, headers, env);
@@ -209,7 +239,6 @@ namespace ChargeBee.Api
         public static String SerializeObject(Object obj)
         {
             return JsonConvert.SerializeObject(obj);
-
         }
     }
 
@@ -222,14 +251,17 @@ namespace ChargeBee.Api
         /// DELETE
         /// </summary>
         DELETE,
+
         /// <summary>
         /// GET
         /// </summary>
         GET,
+
         /// <summary>
         /// POST
         /// </summary>
         POST,
+
         /// <summary>
         /// PUT
         /// </summary>

--- a/ChargeBee/ChargeBee.csproj
+++ b/ChargeBee/ChargeBee.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>2.15.0</Version>
     <PackageId>chargebee</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -59,6 +59,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="lib\" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.24" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>


### PR DESCRIPTION
Hi,

We love Chargebee, but we have a little issue with the SDK. In order to add HTTP monitoring, we need access to add an HttpMessageHandler in the HttpClient. It would be awesome if this is supported in the SDK.